### PR TITLE
🎢🌇 Modifications for multiple video plays

### DIFF
--- a/css/transitions.css
+++ b/css/transitions.css
@@ -4,7 +4,6 @@ video {
   transition: all 0.5s ease;
 }
 
-/* we'll start this at the end of the stack as we're deleting things at the bottom of the stack, and we don't want the pile rotation to change when they're removed */
 .visible {
   transform: scale(1) rotate(0deg);
   opacity: 1;

--- a/css/transitions.css
+++ b/css/transitions.css
@@ -4,6 +4,7 @@ video {
   transition: all 0.5s ease;
 }
 
+/* we'll start this at the end of the stack as we're deleting things at the bottom of the stack, and we don't want the pile rotation to change when they're removed */
 .visible {
   transform: scale(1) rotate(0deg);
   opacity: 1;

--- a/script.js
+++ b/script.js
@@ -61,15 +61,25 @@ const displayGif = src => {
   videosEl.style.display = 'grid'
   videosEl.appendChild(video)
   
+  // We don't want too many videos playing at once, as the performance degrades (and new videos can't be played on iOS)
+  if (document.querySelectorAll('video').length > 9) {
+    // We need to firstly reset the video URL, and then reload it, to free up hardware resources (per this post: https://bugs.webkit.org/show_bug.cgi?id=162366#c32
+    // We don't want to then remove videos, because it changes the orientation of the video stack (due to the nth-child CSS rule)
+    // We only look for videos where the src is not blank (to make sure we don't select a video that we already disabled.
+    const disableVideo =  document.querySelector('video[src]:not([src=""])');
+    disableVideo.setAttribute('src','')
+    disableVideo.load()
+  }
+  
   video.addEventListener('loadeddata', event => {
     video.classList.add('visible')
     document.body.classList.add('has-results')
-    showLoading(false)
   }) 
   
   video.muted = true
   video.playsInline = true
   video.play()
+  showLoading(false)
 }
 
 const createVideo = src => {

--- a/script.js
+++ b/script.js
@@ -74,12 +74,12 @@ const displayGif = src => {
   video.addEventListener('loadeddata', event => {
     video.classList.add('visible')
     document.body.classList.add('has-results')
+    showLoading(false)
   }) 
   
   video.muted = true
   video.playsInline = true
   video.play()
-  showLoading(false)
 }
 
 const createVideo = src => {


### PR DESCRIPTION
New videos weren't loading after a while on iOS Safari, due to the hardware limitations of playing multiple videos at once. Removed old videos to ensure they weren't taking up hardware resources.